### PR TITLE
fixes min restriction

### DIFF
--- a/redis.yaml
+++ b/redis.yaml
@@ -87,7 +87,7 @@ parameters:
     type: number
     default: 2
     constraints:
-      - range: { min: 1 }
+      - length: { min: 1 }
 
   slave_server_hostname:
     label: Slave Hostname


### PR DESCRIPTION
Range restriction must have a max and min value, while length can be
one or the other.
